### PR TITLE
https://github.com/mkhpalm/elastizabbix/issues/10 #fixing 

### DIFF
--- a/agent/elastizabbix
+++ b/agent/elastizabbix
@@ -34,11 +34,22 @@ def get_cache(api):
     lock = '/tmp/elastizabbix-{0}.lock'.format(api)
     should_update = (not os.path.exists(cache)) or is_older_then(cache, ttl)
     if should_update and created_file(lock):
-        with open(cache, 'w') as f: f.write(urllib2.urlopen(stats[api]).read())
-        os.remove(lock)
+        try:
+            d = urllib2.urlopen(stats[api]).read()
+            with open(cache, 'w') as f: f.write(d)
+        except Exception as e:
+            pass        
+        if os.path.exists(lock):
+            os.remove(lock)
     if  os.path.exists(lock) and is_older_then(lock, 300):
         os.remove(lock)
-    return json.load(open(cache))
+    ret_data = {}
+    try:
+        with open(cache)  as data_file:    
+            ret_data = json.load(data_file)        
+    except Exception as e:
+        ret_data = json.loads(urllib2.urlopen(stats[api]).read())
+    return ret_data   
 
 def get_stat(api, stat):
     d = get_cache(api)
@@ -72,6 +83,7 @@ if __name__ == '__main__':
             print discover_nodes()
         if stat == 'indices':
             print discover_indices()
+
     else:
         stat = get_stat(api, stat)
         if isinstance(stat, dict):


### PR DESCRIPTION
Example of issue
`elastizabbix[indices,_all.total.get.time_in_millis]" became not supported: Received value [Traceback (most recent call last):  File "/usr/local/bin/elastizabbix", line 76, in <module>    stat = get_stat(api, stat)  File "/usr/local/bin/elastizabbix", line 44, in get_stat    d = get_cache(api)  File "/usr/local/bin/elastizabbix", line 41, in get_cache    return json.load(open(cache))  File "/usr/lib64/python2.7/json/__init__.py", line 290, in load    **kw)  File "/usr/lib64/python2.7/json/__init__.py", line 338, in loads    return _default_decoder.decode(s)  File "/usr/lib64/python2.7/json/decoder.py", line 365, in decode    obj, end = self.raw_decode(s, idx=_w(s, 0).end())  File "/usr/lib64/python2.7/json/decoder.py", line 383, in raw_decode    raise ValueError("No JSON object could be decoded")ValueError: No JSON object could be decoded] is not suitable for value type [Numeric (unsigned)] and data type [Decimal]
`